### PR TITLE
16 clean up run capsule

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -3,6 +3,9 @@ from typing import List, Optional, Union
 
 from aind_data_schema.base import GenericModel
 
+from analysis_pipeline_utils.metadata import \
+    get_metadata_for_records
+
 from analysis_pipeline_utils.analysis_dispatch_model import \
     AnalysisDispatchModel
 
@@ -85,6 +88,11 @@ def run_analysis(
 
     # Execute analysis and write to results folder
     # using the passed parameters
+    # Example of fetching metadata record from the dispatcher model:
+    # Returns a list of records where each record is a dictionary with the metadata. Example below:
+    #     metadata_records = get_metadata_for_records(analysis_dispatch_inputs)
+    #     first_record = metadata_records[0]
+    #     data_description = first_record["data_description"]
     # Example:
     # Use NWBZarrIO to reads
     # for location in analysis_dispatch_inputs.file_location:
@@ -93,6 +101,7 @@ def run_analysis(
     #     run_your_analysis(nwbfile, analysis_specification)
     # OR
     #     subprocess.run(["--param_1": analysis_specification.param_1])
+    
 
     ### RETURN DICTIONARY MODEL OF OUTPUT PARAMETERS
     output_parameters = {


### PR DESCRIPTION
This PR attempts to clean up `run_capsule.py` by using the updated `analysis_pipeline_utils` function here: https://github.com/AllenNeuralDynamics/analysis-pipeline-utils/blob/272948f5e72c8cae74cedf65db4c933403ab5685/src/analysis_pipeline_utils/utils_analysis_wrapper.py#L75

Users should not have to modify anything inside the main block, and also the example analysis specification and output models have been moved to `run_capsule.py` so only one place needs to be changed

I added this to this PR since it was hopefully just a small change: https://github.com/AllenNeuralDynamics/aind-analysis-wrapper/issues/22

Update: Changed the target branch to release/beta